### PR TITLE
Adds search feature to commands when the URL includes "{q}" or "%s"

### DIFF
--- a/BarLauncher.WebApp.Lib/Service/WebAppResultFinder.cs
+++ b/BarLauncher.WebApp.Lib/Service/WebAppResultFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using BarLauncher.EasyHelper;
 using BarLauncher.EasyHelper.Core.Service;
@@ -328,6 +328,12 @@ namespace BarLauncher.WebApp.Lib.Service
             if (isValid)
             {
                 var url = query.SearchTerms[position];
+                // Added since Chrome requires the url scheme aka "http://" or "https://"
+                // Will break any other url schemes like "ftp://"
+                if (!url.MatchPatternCaseInsensitive("http://") && !url.MatchPatternCaseInsensitive("https://"))
+                {
+                    url = string.Format("https://{0}", url);
+                }
                 yield return GetActionResult
                 (
                     "open {0}".FormatWith(url),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,54 @@
-﻿# To install in Wox
+This is a modified version of the plugin to add the ability to search with commands.
+It adds the ability to use "{q}" or "%s" when adding new URLs, that will be replaced with terms for web search query when using that command.
+
+Example:
+```
+wap add https://duckduckgo.com/?q={q} ddg [default]
+```
+When using that command:
+```
+wap ddg banana split
+```
+Resulting URL used:
+```
+https://duckduckgo.com/?q=banana%20split
+```
+
+Another example:
+```
+wap add https://time.is/?q={q} time [default]
+```
+When using that command:
+```
+wap time paris france
+```
+Resulting URL used:
+```
+https://time.is/?q=paris
+```
+
+Yet another example:
+```
+wap add https://www.urbandictionary.com/define.php?term={q} ud urban urbandictionary [default]
+```
+When using that command:
+```
+wap ud snooze
+```
+Resulting URL used:
+```
+https://www.urbandictionary.com/define.php?term=snooze
+```
+
+# To install in Wox
+
+Follow the original method to install:
 
 ```
 wpm install WebApp launcher
 ```
+
+Then, download the zip file and extract it over the files in the plugin folder say yes if it asks about overwriting files, since this updates 2 DLLs and 2 other files.
 
 # Wox WebApp plugin
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+## Modified to accept search terms for more functionality
 This is a modified version of the plugin to add the ability to search with commands.
 It adds the ability to use "{q}" or "%s" when adding new URLs, that will be replaced with terms for web search query when using that command.
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,22 @@ Follow the original method to install:
 ```
 wpm install WebApp launcher
 ```
+## Find your plugin directory
+- Open Wox settings
+  - In the system tray find the Wox Icon
+  - Right click on it
+  - Click "Settings"
+- Click on the "Plugin" tab
+- Find and click "WebApp launcher" in the list on the left
+- Click "Plugin directory" on the right
 
-Then, download the zip file and extract it over the files in the plugin folder say yes if it asks about overwriting files, since this updates 2 DLLs and 2 other files.
+## Installing modified files
+- **Exit Wox first**
+- Download the `WebApp-launcher_Modified_plugin_files_only.zip`
+- Extract that file over the files in the `WebApp launcher...` folder
+- Start Wox and add new commands to WebApp launcher as desired, see examples above
+
+Full modified plugin files provided if needed in `WebApp-launcher_Full_modified_plugin.zip`
 
 # Wox WebApp plugin
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ wap add https://time.is/?q={q} time [default]
 ```
 When using that command:
 ```
-wap time paris france
+wap time paris
 ```
 Resulting URL used:
 ```


### PR DESCRIPTION
Adds search feature to commands when the URL includes "{q}" or "%s"

Replaces "{q}" or "%s" in a URL when using a command with whatever the user types after the command, handles spaces and replaces them with "%20" to URL encode them in a basic way.

Also ensures that when URLs are started they have either http:// or https:// URL schemes, since Chrome requires a URL scheme to start that URL.

# Examples
```
wap add https://duckduckgo.com/?q={q} ddg [default]
```
When using that command:
```
wap ddg banana split
```
Resulting URL used:
```
https://duckduckgo.com/?q=banana%20split
```

---------------------
```
wap add https://time.is/?q={q} time [default]
```
When using that command:
```
wap time paris
```
Resulting URL used:
```
https://time.is/?q=paris
```

---------------------
```
wap add https://www.urbandictionary.com/define.php?term={q} ud urban urbandictionary [default]
```
When using that command:
```
wap ud snooze
```
Resulting URL used:
```
https://www.urbandictionary.com/define.php?term=snooze
```
